### PR TITLE
Allow library alias using AS instead of WITH NAME

### DIFF
--- a/src/main/java/com/github/nghiatm/robotframeworkplugin/psi/element/HeadingImpl.java
+++ b/src/main/java/com/github/nghiatm/robotframeworkplugin/psi/element/HeadingImpl.java
@@ -32,6 +32,7 @@ public class HeadingImpl extends RobotPsiElementBase implements Heading {
 
     private static final String ROBOT_BUILT_IN = "BuiltIn";
     private static final String WITH_NAME = "WITH NAME";
+    private static final String AS = "AS";
     private static Collection<DefinedVariable> BUILT_IN_VARIABLES = null;
     private Collection<KeywordInvokable> invokedKeywords;
     private MultiMap<String, KeywordInvokable> invokableReferences;
@@ -389,7 +390,7 @@ public class HeadingImpl extends RobotPsiElementBase implements Heading {
     }
 
     /**
-     * Gets the namespace of the current import.  This looks for the 'WITH NAME' tag else returns the first argument.
+     * Gets the namespace of the current import.  This looks for the 'WITH NAME' tag or the 'AS' tag, else returns the first argument.
      *
      * @param imp     the import statement to get the namespace of.
      * @param library the first argument; aka the default namespace
@@ -401,7 +402,7 @@ public class HeadingImpl extends RobotPsiElementBase implements Heading {
         if (args != null) {
             for (int i = 0; i < args.length; i++) {
                 Argument arg = args[i];
-                if (WITH_NAME.equals(arg.getPresentableText())) {
+                if (WITH_NAME.equals(arg.getPresentableText()) || AS.equals(arg.getPresentableText())) {
                     index = i;
                     break;
                 }


### PR DESCRIPTION
Currently, the plugin regards a reference to a library import with `LibraryName    AS    Library` as an error (ie. Library.Keyword will produce a syntax error). However, AS is now the preferred way since RF 6.0, see https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#setting-custom-name-to-library.

As far as I understand the code, my changes fix that. Please test it, I am not sure how to actually pack this into a plugin file I could test with.